### PR TITLE
fix: spliting names correctly.

### DIFF
--- a/script.py
+++ b/script.py
@@ -58,6 +58,7 @@ while(1):
 #print("title: " + title)
 
 titleParts = title.split('?')[1]
+titleParts = titleParts.replace(' ou ', ', ')
 
 #print(titleParts)
 


### PR DESCRIPTION
O script falhava na hora de separar os nomes, pois esparava uma "," e estava recebendo um " ou ". Dessa forma, antes do split, foi feito um replace do " ou " por uma ",". O problema está relacionado a [seguinte issue](https://github.com/izmcm/BBBot/issues/26)